### PR TITLE
Context incorrect in IE 9 each() call

### DIFF
--- a/src/prototype/lang/array.js
+++ b/src/prototype/lang/array.js
@@ -187,7 +187,7 @@ Array.from = $A;
 (function() {
   var arrayProto = Array.prototype,
       slice = arrayProto.slice,
-      _each = arrayProto.forEach; // use native browser JS 1.6 implementation if available
+      _each = Prototype.Browser.IE ? null : arrayProto.forEach; // use native browser JS 1.6 implementation if available
 
   function each(iterator, context) {
     for (var i = 0, length = this.length >>> 0; i < length; i++) {


### PR DESCRIPTION
[Browser window 1]

``` javascript
parent.opener.Foo.bar();
```

[browser window 2]

``` javascript
var Foo {
  variable: 1,

  bar: function()
  {
    [ 1 ].each(function() {
      if (!this.variable) {
        // This code is incorrectly reached: this.variable should exist
       }
    }, this);
  }
};
```

Inside of the each() method, this is NOT the Foo object - it is instead the window DOM object (not sure if it is the window DOM object of window 1 or 2, but it doesn't really matter).

The hotfix is to not use the native forEach method in IE and instead use the prototypejs version.
